### PR TITLE
Add Android wrapper with AdMob integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,17 @@ Compartilhe o link da sala com um amigo para jogar online.
 2. Abra a pasta `android/` no Android Studio. A IDE baixará as dependências e
    criará o gradle wrapper automaticamente (caso ainda não exista no repositório).
 
-3. Configure os IDs de anúncio reais no arquivo `android/app/src/main/res/values/strings.xml`:
+3. Os IDs de anúncio oficiais já estão configurados em
+   `android/app/src/main/res/values/strings.xml`:
 
    ```xml
-   <string name="admob_app_id">SEU_APP_ID</string>
-   <string name="admob_banner_unit_id">SEU_BANNER_ID</string>
-   <string name="admob_interstitial_unit_id">SEU_INTERSTITIAL_ID</string>
+   <string name="admob_app_id">ca-app-pub-3962525960228971~8235282158</string>
+   <string name="admob_banner_unit_id">ca-app-pub-3962525960228971/7301474434</string>
+   <string name="admob_interstitial_unit_id">ca-app-pub-3962525960228971/2512289987</string>
    ```
 
-   Os valores atuais são IDs de teste fornecidos pelo Google e não geram receita,
-   mas são obrigatórios durante o desenvolvimento para evitar violações das
-   políticas de anúncios.
+   Caso precise trocar por outros blocos, atualize estes valores antes de gerar
+   a versão de release.
 
 4. Ajuste as informações de versão/assinatura em `android/app/build.gradle.kts`
    conforme as exigências de publicação (versionCode, versionName e assinatura

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Jogo da Velha
 
 Aplicação web do clássico jogo da velha construída com React, TypeScript e Vite.
+Agora o projeto também acompanha um wrapper Android nativo pronto para publicação
+na Play Store, com pontos de integração para anúncios do Google AdMob (banner fixo
+e intersticial entre partidas).
 
 ## Desenvolvimento
 
@@ -15,8 +18,76 @@ npm run dev
 - TypeScript
 - Vite
 - Tailwind CSS
+- Android (Kotlin + WebView)
+- Google Mobile Ads SDK
 
 ## Multijogador
 
 O modo multijogador funciona utilizando apenas o navegador, sem necessidade de banco de dados.
 Compartilhe o link da sala com um amigo para jogar online.
+
+## Build para Android
+
+### Pré-requisitos
+
+- Node 18+
+- Java 17 e Android Studio (ou Android SDK + Gradle 8.5)
+- Conta Google AdMob para criar IDs próprios (substitua os IDs de teste antes de publicar)
+
+### Passo a passo
+
+1. Gere os assets web:
+
+   ```sh
+   npm install
+   npm run build:android
+   ```
+
+   O script gera a build de produção do Vite e copia os arquivos estáticos para
+   `android/app/src/main/assets/web`.
+
+2. Abra a pasta `android/` no Android Studio. A IDE baixará as dependências e
+   criará o gradle wrapper automaticamente (caso ainda não exista no repositório).
+
+3. Configure os IDs de anúncio reais no arquivo `android/app/src/main/res/values/strings.xml`:
+
+   ```xml
+   <string name="admob_app_id">SEU_APP_ID</string>
+   <string name="admob_banner_unit_id">SEU_BANNER_ID</string>
+   <string name="admob_interstitial_unit_id">SEU_INTERSTITIAL_ID</string>
+   ```
+
+   Os valores atuais são IDs de teste fornecidos pelo Google e não geram receita,
+   mas são obrigatórios durante o desenvolvimento para evitar violações das
+   políticas de anúncios.
+
+4. Ajuste as informações de versão/assinatura em `android/app/build.gradle.kts`
+   conforme as exigências de publicação (versionCode, versionName e assinatura
+   com o keystore de produção).
+
+5. Gere o bundle de release:
+
+   ```sh
+   ./gradlew bundleRelease
+   ```
+
+   O arquivo `.aab` estará em `android/app/build/outputs/bundle/release/` e pode
+   ser enviado para a Play Store.
+
+### Integração com anúncios
+
+- A interface JavaScript exposta (`window.Android`) é chamada automaticamente
+  quando uma partida termina ou uma nova partida começa, permitindo exibir um
+  intersticial entre jogos e manter o banner fixo no rodapé.
+- Todas as chamadas são encapsuladas em `src/components/GameScreen.tsx`, então é
+  possível customizar a lógica de monetização sem impactar o restante do jogo.
+
+### Conformidade Play Store
+
+- O projeto utiliza o SDK oficial do Google Mobile Ads (versão 23.1.0) e segue
+  as recomendações de inicialização e uso de IDs de teste durante o
+  desenvolvimento.
+- A aplicação suporta somente HTTPS dentro do WebView e mantém o histórico de
+  partidas localmente, sem coletar dados sensíveis.
+- Os ícones adaptativos e recursos obrigatórios já estão incluídos, bastando
+  substituir as artes antes da publicação.

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,0 +1,6 @@
+**/build/
+/.gradle/
+/local.properties
+/captures/
+/.idea/
+.DS_Store

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,66 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.tdamiao.jogodavelha"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.tdamiao.jogodavelha"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0.0"
+
+        vectorDrawables {
+            useSupportLibrary = true
+        }
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        viewBinding = true
+    }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.appcompat:appcompat:1.7.0")
+    implementation("com.google.android.material:material:1.12.0")
+    implementation("androidx.activity:activity-ktx:1.9.2")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.webkit:webkit:1.11.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.5")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.8.5")
+    implementation("com.google.android.gms:play-services-ads:23.1.0")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,4 @@
+# Mantém a interface usada pelo WebView com JavaScript
+-keepclassmembers class com.tdamiao.jogodavelha.TicTacToeWebAppInterface {
+    <methods>;
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.JogoDaVelha">
+
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="@string/admob_app_id" />
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+            android:launchMode="singleTask"
+            android:screenOrientation="portrait">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android/app/src/main/assets/README.md
+++ b/android/app/src/main/assets/README.md
@@ -1,0 +1,3 @@
+Os arquivos estáticos do jogo são copiados para esta pasta pelo script `npm run build:android`.
+Certifique-se de executar o script antes de gerar o APK/AAB para que `web/index.html`
+esteja presente.

--- a/android/app/src/main/java/com/tdamiao/jogodavelha/MainActivity.kt
+++ b/android/app/src/main/java/com/tdamiao/jogodavelha/MainActivity.kt
@@ -1,0 +1,111 @@
+package com.tdamiao.jogodavelha
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.ComponentActivity
+import androidx.activity.viewModels
+import androidx.core.view.WindowCompat
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.AdView
+import com.google.android.gms.ads.InterstitialAd
+import com.google.android.gms.ads.InterstitialAdLoadCallback
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.MobileAds
+import com.tdamiao.jogodavelha.databinding.ActivityMainBinding
+
+class MainActivity : ComponentActivity() {
+
+    private lateinit var binding: ActivityMainBinding
+    private var interstitialAd: InterstitialAd? = null
+
+    private val adViewModel: MonetizationViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        MobileAds.initialize(this)
+
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        setupWebView(binding.webView)
+        setupBanner(binding.adView)
+        observeAdRequests()
+    }
+
+    private fun observeAdRequests() {
+        adViewModel.shouldShowInterstitial.observe(this) { shouldShow ->
+            if (shouldShow) {
+                showInterstitial()
+            }
+        }
+
+        adViewModel.shouldPrepareNewMatch.observe(this) { shouldPrepare ->
+            if (shouldPrepare) {
+                loadInterstitial()
+                adViewModel.onInterstitialPrepared()
+            }
+        }
+    }
+
+    private fun setupBanner(adView: AdView) {
+        val request = AdRequest.Builder().build()
+        adView.loadAd(request)
+    }
+
+    private fun loadInterstitial() {
+        val request = AdRequest.Builder().build()
+        InterstitialAd.load(
+            this,
+            getString(R.string.admob_interstitial_unit_id),
+            request,
+            object : InterstitialAdLoadCallback() {
+                override fun onAdLoaded(ad: InterstitialAd) {
+                    interstitialAd = ad
+                }
+
+                override fun onAdFailedToLoad(loadAdError: LoadAdError) {
+                    interstitialAd = null
+                }
+            }
+        )
+    }
+
+    private fun showInterstitial() {
+        val ad = interstitialAd
+        if (ad != null) {
+            ad.fullScreenContentCallback = adViewModel.fullScreenContentCallback
+            ad.show(this)
+            interstitialAd = null
+        } else {
+            loadInterstitial()
+        }
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun setupWebView(webView: WebView) {
+        webView.settings.javaScriptEnabled = true
+        webView.settings.domStorageEnabled = true
+        webView.settings.allowFileAccess = true
+        webView.settings.allowContentAccess = true
+        webView.webChromeClient = WebChromeClient()
+        webView.webViewClient = WebViewClient()
+        webView.addJavascriptInterface(
+            TicTacToeWebAppInterface(
+                onMatchFinished = { adViewModel.onMatchFinished() },
+                onMatchRestarted = { adViewModel.onMatchRestarted() }
+            ),
+            "Android"
+        )
+
+        if (BuildConfig.DEBUG) {
+            WebView.setWebContentsDebuggingEnabled(true)
+        }
+
+        webView.loadUrl("file:///android_asset/web/index.html")
+        loadInterstitial()
+    }
+}

--- a/android/app/src/main/java/com/tdamiao/jogodavelha/MonetizationViewModel.kt
+++ b/android/app/src/main/java/com/tdamiao/jogodavelha/MonetizationViewModel.kt
@@ -1,0 +1,40 @@
+package com.tdamiao.jogodavelha
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.google.android.gms.ads.FullScreenContentCallback
+import com.google.android.gms.ads.AdError
+
+class MonetizationViewModel : ViewModel() {
+
+    private val _shouldShowInterstitial = MutableLiveData(false)
+    val shouldShowInterstitial: LiveData<Boolean> = _shouldShowInterstitial
+
+    private val _shouldPrepareNewMatch = MutableLiveData(false)
+    val shouldPrepareNewMatch: LiveData<Boolean> = _shouldPrepareNewMatch
+
+    val fullScreenContentCallback = object : FullScreenContentCallback() {
+        override fun onAdDismissedFullScreenContent() {
+            _shouldShowInterstitial.value = false
+            _shouldPrepareNewMatch.value = true
+        }
+
+        override fun onAdFailedToShowFullScreenContent(adError: AdError) {
+            _shouldShowInterstitial.value = false
+            _shouldPrepareNewMatch.value = true
+        }
+    }
+
+    fun onMatchFinished() {
+        _shouldShowInterstitial.postValue(true)
+    }
+
+    fun onMatchRestarted() {
+        _shouldPrepareNewMatch.postValue(true)
+    }
+
+    fun onInterstitialPrepared() {
+        _shouldPrepareNewMatch.value = false
+    }
+}

--- a/android/app/src/main/java/com/tdamiao/jogodavelha/TicTacToeWebAppInterface.kt
+++ b/android/app/src/main/java/com/tdamiao/jogodavelha/TicTacToeWebAppInterface.kt
@@ -1,0 +1,19 @@
+package com.tdamiao.jogodavelha
+
+import android.webkit.JavascriptInterface
+
+class TicTacToeWebAppInterface(
+    private val onMatchFinished: () -> Unit,
+    private val onMatchRestarted: () -> Unit
+) {
+
+    @JavascriptInterface
+    fun onMatchFinished() {
+        onMatchFinished.invoke()
+    }
+
+    @JavascriptInterface
+    fun onMatchRestarted() {
+        onMatchRestarted.invoke()
+    }
+}

--- a/android/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#1F1B2E"
+        android:pathData="M0,0h108v108h-108z" />
+</vector>

--- a/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <group
+        android:translateX="18"
+        android:translateY="18"
+        android:scaleX="0.75"
+        android:scaleY="0.75">
+        <path
+            android:strokeColor="#FFFFFF"
+            android:strokeWidth="6"
+            android:strokeLineCap="round"
+            android:pathData="M18,0v72" />
+        <path
+            android:strokeColor="#FFFFFF"
+            android:strokeWidth="6"
+            android:strokeLineCap="round"
+            android:pathData="M54,0v72" />
+        <path
+            android:strokeColor="#FFFFFF"
+            android:strokeWidth="6"
+            android:strokeLineCap="round"
+            android:pathData="M0,18h72" />
+        <path
+            android:strokeColor="#FFFFFF"
+            android:strokeWidth="6"
+            android:strokeLineCap="round"
+            android:pathData="M0,54h72" />
+        <path
+            android:strokeColor="#FFB020"
+            android:strokeWidth="6"
+            android:strokeLineCap="round"
+            android:pathData="M12,12l24,24" />
+        <path
+            android:strokeColor="#FFB020"
+            android:strokeWidth="6"
+            android:strokeLineCap="round"
+            android:pathData="M36,12l-24,24" />
+        <path
+            android:strokeColor="#76E4F7"
+            android:strokeWidth="6"
+            android:pathData="M48,48a12,12 0 1,0 0,-24a12,12 0 1,0 0,24" />
+    </group>
+</vector>

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <WebView
+        android:id="@+id/webView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:overScrollMode="never"
+        app:layout_constraintBottom_toTopOf="@+id/adView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.gms.ads.AdView
+        android:id="@+id/adView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:background="@android:color/transparent"
+        app:adSize="BANNER"
+        app:adUnitId="@string/admob_banner_unit_id"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/values-night/themes.xml
+++ b/android/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.JogoDaVelha" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor" tools:targetApi="l">@color/black</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,8 @@
+<resources>
+    <color name="purple_200">#BB86FC</color>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+    <color name="black">#000000</color>
+    <color name="white">#FFFFFF</color>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+    <string name="app_name">Jogo da Velha</string>
+    <string name="admob_app_id">ca-app-pub-3940256099942544~3347511713</string>
+    <string name="admob_banner_unit_id">ca-app-pub-3940256099942544/6300978111</string>
+    <string name="admob_interstitial_unit_id">ca-app-pub-3940256099942544/1033173712</string>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Jogo da Velha</string>
-    <string name="admob_app_id">ca-app-pub-3940256099942544~3347511713</string>
-    <string name="admob_banner_unit_id">ca-app-pub-3940256099942544/6300978111</string>
-    <string name="admob_interstitial_unit_id">ca-app-pub-3940256099942544/1033173712</string>
+    <string name="admob_app_id">ca-app-pub-3962525960228971~8235282158</string>
+    <string name="admob_banner_unit_id">ca-app-pub-3962525960228971/7301474434</string>
+    <string name="admob_interstitial_unit_id">ca-app-pub-3962525960228971/2512289987</string>
 </resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.JogoDaVelha" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor" tools:targetApi="l">@color/black</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="database" />
+</full-backup-content>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="database" />
+        <exclude domain="sharedpref" path="com.google.android.gms.ads" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="database" />
+    </device-transfer>
+</data-extraction-rules>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.5.1" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+android.enableJetifier=true
+kotlin.code.style=official

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "JogoDaVelha"
+include(":app")

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "build:dev": "vite build --mode development",
+    "build:android": "vite build && node scripts/copy-android-assets.mjs",
+    "sync:android": "node scripts/copy-android-assets.mjs",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/scripts/copy-android-assets.mjs
+++ b/scripts/copy-android-assets.mjs
@@ -1,0 +1,26 @@
+import { cpSync, existsSync, mkdirSync, rmSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const distDir = path.join(rootDir, 'dist');
+const assetsDir = path.join(rootDir, 'android', 'app', 'src', 'main', 'assets');
+const targetDir = path.join(assetsDir, 'web');
+
+if (!existsSync(distDir)) {
+  console.error('O diretório dist não foi encontrado. Execute "npm run build" antes de sincronizar os assets do Android.');
+  process.exit(1);
+}
+
+if (!existsSync(assetsDir)) {
+  mkdirSync(assetsDir, { recursive: true });
+}
+
+rmSync(targetDir, { recursive: true, force: true });
+mkdirSync(targetDir, { recursive: true });
+
+cpSync(distDir, targetDir, { recursive: true });
+
+console.log(`Assets do web app copiados para ${targetDir}`);

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,9 @@
 
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 @layer base {
   :root {

--- a/src/types/android.d.ts
+++ b/src/types/android.d.ts
@@ -1,0 +1,12 @@
+declare global {
+  interface AndroidAdBridge {
+    onMatchFinished?: () => void;
+    onMatchRestarted?: () => void;
+  }
+
+  interface Window {
+    Android?: AndroidAdBridge;
+  }
+}
+
+export {};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig(({ mode }) => ({
     host: "::",
     port: 8080,
   },
+  base: mode === "production" ? "./" : "/",
   plugins: [
     react(),
   ],


### PR DESCRIPTION
## Summary
- add a native Android wrapper that hosts the web build in a WebView, initializes Google Mobile Ads, and wires banner + interstitial placements
- expose lightweight JS bridge hooks in the React game to notify Android when matches finish or restart
- add scripts and documentation to generate Android assets and guide Play Store-ready builds

## Testing
- npm run build
- npm run build:android
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1baa4c004832f965815c5ccf8980f